### PR TITLE
Upgrade just to 1.52.0

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,6 +1,6 @@
 [tools]
 rust = "nightly"
-just = "1.46.0"
+just = "1.52.0"
 node = "24.13.0"
 "npm:markdownlint-cli2" = "0.18.1"
 "npm:prettier" = "3.8.1"


### PR DESCRIPTION
Bumps the pinned `just` version to 1.52.0 in `.mise/config.toml` to match the project-template baseline.